### PR TITLE
fix: remove webpack startup error

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,6 @@ module.exports = {
     rules: [
       {
         test: /\.mjs$/,
-        exclude: /node_modules/,
         type: 'javascript/auto',
       },
       {


### PR DESCRIPTION
Fixes following dev server startup error:
`
/home/ktor/development/projects/lukreo/liferay/modules/application/com.lukreo.application.items.react/node_modules/@clavis/lfr-js-portlet-utils/node_modules/we
bpack/lib/RuleSet.js:167
                                throw new Error(
                                      ^

Error: Rule can only have one resource source (provided resource and test + include + exclude) in {
  "exclude": {},
  "type": "javascript/auto",
  "use": []
}
`